### PR TITLE
fix: trade details order by priority

### DIFF
--- a/src/components/trade-info/index.tsx
+++ b/src/components/trade-info/index.tsx
@@ -47,6 +47,11 @@ const TradeInfoSection = ({
   return (
     <div className="flex flex-col gap-3">
       <TransactionInfo
+        label="Price impact"
+        tooltipContent="The impact your trade has on the market price of this pool"
+        value={formatPercent(priceImpact)}
+      />
+      <TransactionInfo
         label="$GOATAI fee (6%)"
         tooltipContent={
           <div>
@@ -106,11 +111,7 @@ const TradeInfoSection = ({
         tooltipContent="Your transaction will revert if the price slips more than the slippage percentage."
         value={formatPercent(slippage)}
       />
-      <TransactionInfo
-        label="Price impact"
-        tooltipContent="The impact your trade has on the market price of this pool"
-        value={formatPercent(priceImpact)}
-      />
+
       {isReviewModal && (
         <TransactionInfo
           label="Rate"

--- a/src/lib/utils/format-number.ts
+++ b/src/lib/utils/format-number.ts
@@ -337,7 +337,7 @@ export function formatNumber({
   const { formatterOptions, hardCodedInput } = getFormatterRule(input, type, conversionRate);
 
   if (formatterOptions.currency) {
-    input = conversionRate ? input * conversionRate : input;
+    input = conversionRate !== undefined ? input * conversionRate : input;
     formatterOptions.currency = 'USD';
   }
 

--- a/src/screens/swap/index.tsx
+++ b/src/screens/swap/index.tsx
@@ -2,12 +2,6 @@ import CurrencyBox from '@/components/currency-box';
 import SwapReviewModal from '@/components/swap-review-modal';
 import TradeInfoSection from '@/components/trade-info';
 import TransactionSettings from '@/components/transaction-settings';
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from '@/components/ui/accordion';
 import { Button } from '@/components/ui/button';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { ConnectWalletButton } from '@/components/wallet-provider';
@@ -189,17 +183,8 @@ const SwapSection = ({
 
       {swapAmounts[SwapMode.SELL].rawValue && swapAmounts[SwapMode.BUY].rawValue ?
         <div className="-my-4">
-          <Accordion className="w-full" collapsible type="single">
-            <AccordionItem value="item-1">
-              <div className="flex flex-row items-center justify-between gap-2">
-                <SwapRateDisplay selectedTokens={selectedTokens} swapAmounts={swapAmounts} />
-                <AccordionTrigger className="cursor-pointer" />
-              </div>
-              <AccordionContent>
-                <TradeInfoSection selectedTokens={selectedTokens} swapAmounts={swapAmounts} />
-              </AccordionContent>
-            </AccordionItem>
-          </Accordion>
+          <SwapRateDisplay selectedTokens={selectedTokens} swapAmounts={swapAmounts} />
+          <TradeInfoSection selectedTokens={selectedTokens} swapAmounts={swapAmounts} />
         </div>
       : null}
 


### PR DESCRIPTION
Closes [10](https://github.com/franzmoro/gta-swap/issues/10)

- [x] Show the trade details under swap section always
- [x] Update the order of the trade details :
         - Price impact
         - GOATAI fee
         - Trade fee
         - network cost
         - slippage